### PR TITLE
fix: correct wgsl module type declaration

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,5 @@
 declare module '*.wgsl' {
-    const shader: 'string';
+    const shader: string;
     export default shader;
   }
 


### PR DESCRIPTION
## Summary
- remove stray quotes from WGSL module declaration

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840495b544083209ee55905d5febff5