### PR TITLE
Fix grid pipeline integration

### DIFF
--- a/src/engine/render/pipelineDescriptors/pipelineManager.ts
+++ b/src/engine/render/pipelineDescriptors/pipelineManager.ts
@@ -2,6 +2,7 @@ import { BufferManager } from "../buffers/bufferManager";
 import { screenPipelineDescriptor } from "./screenPipelineDescription";
 import { computePipelineDescriptor } from "./computePipelineDescription";
 import { VoxelComputePipelineDescriptor } from "./raytracePipelineDescription";
+import { GridPipelineDescriptor } from "./editor/gridPipelineDescription";
 import { VoxelBufferManager } from "../buffers/voxel/voxelBufferManager";
 
 export class PipelineManager {
@@ -10,12 +11,14 @@ export class PipelineManager {
     screenPipeline!: screenPipelineDescriptor;
     computePipeline!: computePipelineDescriptor;
     voxelPipeline!: VoxelComputePipelineDescriptor;
+    gridPipeline!: GridPipelineDescriptor;
 
     constructor(device: GPUDevice, bufferManager: BufferManager, voxelBufferManager?: VoxelBufferManager) {
         this.device = device;
 
         this.screenPipeline = new screenPipelineDescriptor(this.device, bufferManager);
         this.computePipeline = new computePipelineDescriptor(this.device, bufferManager);
+        this.gridPipeline = new GridPipelineDescriptor(this.device, bufferManager);
         
         // Initialize voxel pipeline if buffer manager is provided
         if (voxelBufferManager) {


### PR DESCRIPTION
## Summary
- integrate GridPipelineDescriptor with PipelineManager
- ensure GridRenderPass can access grid pipeline

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68405237026083208332de32e249dfd7